### PR TITLE
Usage中代码少一个括弧

### DIFF
--- a/site/components/formatter/index.md
+++ b/site/components/formatter/index.md
@@ -9,7 +9,7 @@
 ## Usage
 ``` js
 var Formatter = require("uxcore-formatter");
-console.log(Formatter.date(new Date(), 'YYYY-MM-DD');
+console.log(Formatter.date(new Date(), 'YYYY-MM-DD'));
 ```
 
 ## API


### PR DESCRIPTION
`console.log(Formatter.date(new Date(), 'YYYY-MM-DD')`缺一个括弧，会导致运行报错。